### PR TITLE
Use ConvertTo-Json in Connect-vRAServer

### DIFF
--- a/src/Functions/Public/Connect-vRAServer.ps1
+++ b/src/Functions/Public/Connect-vRAServer.ps1
@@ -138,13 +138,11 @@
     try {
 
         # --- Create Invoke-RestMethod Parameters
-        $JSON = @"
-        {
-            "username":"$($Username)",
-            "password":"$($JSONPassword)",
-            "tenant":"$($Tenant)"
-        }
-"@
+        $JSON = @{
+            username = $Username
+            password = $JSONPassword
+            tenant = $Tenant
+        } | ConvertTo-Json
 
         $Params = @{
 


### PR DESCRIPTION
Creating JSON using embedded variables in a string can easily break if the user's input contains special characters. In my case, my password would break the encoding and the server would error out. This can be the case, for example, if the password contains a double quote, ends with a backslash, etc...